### PR TITLE
Avoid unlocking issues.

### DIFF
--- a/islandora_object_lock.module
+++ b/islandora_object_lock.module
@@ -193,6 +193,16 @@ function islandora_object_lock_set_object_lock($pid, $user = NULL, $duration = N
  *   The object's PID.
  */
 function islandora_object_lock_remove_object_lock($pid) {
+  $unlocking =& drupal_static(__FUNCTION__, array());
+
+  if (isset($unlocking[$pid])) {
+    // In the process of unlocking; let's not explode.
+    return;
+  }
+  else {
+    $unlocking[$pid] = $pid;
+  }
+
   // XXX: The connection may be created without credentials (when your site's
   // front page is 'islandora/object/some:object', for example). Resetting to
   // ensure a new connection gets created should fix it.
@@ -229,6 +239,8 @@ function islandora_object_lock_remove_object_lock($pid) {
   drupal_static_reset('islandora_get_tuque_connection');
   $tuque = islandora_get_tuque_connection();
   $tuque->cache->delete($pid);
+
+  unset($unlocking[$pid]);
 }
 
 /**

--- a/islandora_object_lock.module
+++ b/islandora_object_lock.module
@@ -200,7 +200,7 @@ function islandora_object_lock_remove_object_lock($pid) {
     return;
   }
   else {
-    $unlocking[$pid] = $pid;
+    $unlocking[$pid] = TRUE;
   }
 
   // XXX: The connection may be created without credentials (when your site's


### PR DESCRIPTION
Modifications to RELS-INT during unlocking w/ "unlock on modifcation" enabled
can make a mess... stop unlocking from re-entering.

To reproduce:
1. Create an object
2. Using the XACML editor/API, restrict access to an existing datastream on this object.
3. Acquire the lock for the given object.
4. With "islandora_object_lock_lift_lock_on_modify" enabled, modify a datastream not covered by `hook_islandora_object_lock_ignored_datastream_modifications()` (anything other than RELS-EXT and POLICY, by default). Should end up in a recursive loop:
    1. [Attempting to remove the lock, as a result of the datastream modification](https://github.com/discoverygarden/islandora_object_lock/blob/656635a4d17559890c359959856c59e4f5e9a8e5/islandora_object_lock.module#L120)
    2. Modifying a datastream, alternating between:
        1. [Removing the first RELS-INT statement](https://github.com/Islandora/islandora_xacml_editor/blob/ed2cb7b5ad036470afa2e763d12c13849c611568/api/includes/islandora_xacml.inc#L88)
        2. [Adding the first RELS-INT statement](https://github.com/Islandora/islandora_xacml_editor/blob/ed2cb7b5ad036470afa2e763d12c13849c611568/api/includes/islandora_xacml.inc#L112)

This pull request prevents the recursion from happening by preventing unlocking of the given object being processed as a result of unlocking the given object.