### PR TITLE
Reset ALL the cache!

### DIFF
--- a/islandora_object_lock.module
+++ b/islandora_object_lock.module
@@ -209,7 +209,7 @@ function islandora_object_lock_remove_object_lock($pid) {
   drupal_static_reset('islandora_get_tuque_connection');
   $user = user_load(1);
   $tuque = islandora_get_tuque_connection($user);
-  $tuque->cache->delete($pid);
+  $tuque->cache->resetCache();
   $object = islandora_object_load($pid);
   $locking_user = islandora_object_lock_get_lock_username($object);
 
@@ -238,7 +238,7 @@ function islandora_object_lock_remove_object_lock($pid) {
 
   drupal_static_reset('islandora_get_tuque_connection');
   $tuque = islandora_get_tuque_connection();
-  $tuque->cache->delete($pid);
+  $tuque->cache->resetCache();
 
   unset($unlocking[$pid]);
 }


### PR DESCRIPTION
There exists the potential to leak objects which might have been loaded with
elevated permissions... [`::resetCache()` isn't strictly part of the interface](https://github.com/Islandora/tuque/blob/fd3051ddfbc9d12b84c92bcc34ec2981edf89ca0/Cache.php#L9-L66);
however, the ["Tuque" class defines it as a SimpleCache instance](https://github.com/Islandora/islandora/blob/1c7e041d69a41b2a0ce3fad6f1a2e0392981ad39/includes/tuque.inc#L47-L52), which _does_ have the `::resetCache()` method (in a sense... it's static, but... semantics)... let's do it!